### PR TITLE
Leaderboards into SvelteKit Endpoints

### DIFF
--- a/src/routes/api/[user].ts
+++ b/src/routes/api/[user].ts
@@ -59,6 +59,7 @@ export async function get({ params }) {
 	} catch (err) {
 		console.error(err);
 		return {
+      status: 500,
 			body: {
 				iserror: true,
 				error_msg: err.toString(),

--- a/src/routes/leaderboards/api/[type].ts
+++ b/src/routes/leaderboards/api/[type].ts
@@ -1,0 +1,24 @@
+/**
+ * @type {import('@sveltejs/kit').RequestHandler}
+ */
+export async function get({ params }) {
+	const { type } = params;
+	try {
+		let leaderboard = {};
+		leaderboard = await (
+			await fetch(`https://scratchdb.lefty.one/v3/user/rank/global/${type}`)
+		).json();
+		return {
+			body: leaderboard,
+		};
+	} catch (err) {
+		console.error(err);
+		return {
+      status: 500,
+			body: {
+				iserror: true,
+				error_msg: err.toString(),
+			},
+		};
+	}
+}


### PR DESCRIPTION
All Leaderboards API requests should go into sveltekit endpoints instead of directly to ScratchDB.