### PR TITLE
Use isScratcher for scratcher check

### DIFF
--- a/src/lib/getStatus.ts
+++ b/src/lib/getStatus.ts
@@ -1,12 +1,13 @@
 export async function getStatus(user: string) {
-  const r = await fetch(`https://scratchdb.lefty.one/v3/user/info/${user}`, {
-    headers: {
-      'User-Agent': 'Mozilla 5.0'
-    }
-  });
+  const r = await fetch(`https://isscratcher.9pfs.repl.co/api/${user}`); // isScratcher doesn't care about the user agent string
   if (!r.ok) {
-    throw new Error('scratchdb doesnt know');
+    throw new Error('scratch doesn\'t know that username');
   }
   const rJSON = await r.json();
-  return rJSON.status.trim();
+  if(rJSON.isScratcher==false) {
+    return "New Scratcher";
+  }
+  else {
+    return "Scratcher"; // Will say that Scratch Team members are scratchers, but can't be fixed currently due to isScratcher limitations. However, since Scratch Team members have no extra privileges, it's fine for now.
+  }
 }


### PR DESCRIPTION
Will respond with up-to-date data and save a few bytes on the user agent header. Closes #52 (Fun fact: PRs can close PRs. I learned that while experimenting)