### PR TITLE
Add fallback when ScratchDB forgets to `res.send()`

### DIFF
--- a/src/routes/api/[user].ts
+++ b/src/routes/api/[user].ts
@@ -8,7 +8,22 @@ export async function get({ params }) {
       await fetch(`https://api.scratch.mit.edu/users/${user}/`)
     ).json();
     let scratchdb,
-      scratchdb_forum_user = { counts: undefined };
+      scratchdb_forum_user = {
+        counts: {
+          "total":{"count":0,"rank":1},
+          "Advanced Topics":{"count":0,"rank":1},
+        },
+        "history":[
+          {"date":"1234-12-23T12:34:56.000Z","value":1},
+        ],
+        "firstSeen":{
+          "date":"1234-12-23T12:34:56.000Z","id":1
+        },
+        "lastSeen":{
+          "date":"1234-12-23T12:34:56.000Z","id":1
+        },
+        "signature":"Well, that one fell off the database. ScratchDB didn't know what to say.",
+      };
     scratchdb = await (await fetch(`https://scratchdb.lefty.one/v3/user/info/${user}`)).json();
     scratchdb_forum_user = await (
       await fetch(`https://scratchdb.lefty.one/v3/forum/user/info/${user}`)

--- a/src/routes/api/[user].ts
+++ b/src/routes/api/[user].ts
@@ -25,9 +25,19 @@ export async function get({ params }) {
         "signature":"Well, that one fell off the database. ScratchDB didn't know what to say.",
       };
     scratchdb = await (await fetch(`https://scratchdb.lefty.one/v3/user/info/${user}`)).json();
-    scratchdb_forum_user = await (
-      await fetch(`https://scratchdb.lefty.one/v3/forum/user/info/${user}`)
-    ).json();
+    if(user==="null") {
+      // Suspect scratchDB used == instead of ===
+    }
+    else {
+      try {
+      scratchdb_forum_user = await (
+        await fetch(`https://scratchdb.lefty.one/v3/forum/user/info/${user}`)
+      ).json();
+      }
+      catch(e) {
+        scratchdb_forum_user.signature="Well, ScratchDB didn't know. So we don't know."
+      }
+    }
     let ocular = { status: undefined, color: undefined };
     try {
       ocular = await (await fetch(`https://my-ocular.jeffalo.net/api/user/${user}/`)).json();


### PR DESCRIPTION
Resolves #50 
(maybe)

- [x] If this checkbox isn't checked, I'm not finished yet. I need to change something.